### PR TITLE
fix can't work with react-native-web

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
   "dependencies": {
     "assert": "^2.0.0",
     "buffer": "^6.0.3",
-    "stream": "^0.0.2"
+    "stream-browserify": "3.0.0"
   }
 }

--- a/src/chunkstream.js
+++ b/src/chunkstream.js
@@ -1,7 +1,7 @@
 "use strict";
 
 let util = require("util");
-let Stream = require("stream");
+let Stream = require("stream-browserify");
 
 let ChunkStream = (module.exports = function () {
   Stream.call(this);

--- a/src/packer-async.js
+++ b/src/packer-async.js
@@ -1,7 +1,7 @@
 "use strict";
 
 let util = require("util");
-let Stream = require("stream");
+let Stream = require("stream-browserify");
 let constants = require("./constants");
 let Packer = require("./packer");
 

--- a/src/png.js
+++ b/src/png.js
@@ -1,7 +1,7 @@
 "use strict";
 
 let util = require("util");
-let Stream = require("stream");
+let Stream = require("stream-browserify");
 let Parser = require("./parser-async");
 let Packer = require("./packer-async");
 let PNGSync = require("./png-sync");


### PR DESCRIPTION
because there is no `Stream.Readable` in `node_modules/stream`, thus will let other module which need `Stream.Readable` can't even use `stream: require.resolve('stream-browserify')` in `config-overrides.js` , ref to

    https://github.com/flyskywhy/GCanvasRNExamples/blob/3c0f617cce84ac73c097f8529a85db1daae43a02/config-overrides.js#L31

And please `npm publish` a new version, thanks!